### PR TITLE
Use base class validate_config and remove redundant code

### DIFF
--- a/roles/scaffold_resource_module/templates/module_utils/network_os/facts/resource/resource.py.j2
+++ b/roles/scaffold_resource_module/templates/module_utils/network_os/facts/resource/resource.py.j2
@@ -34,16 +34,6 @@ class {{ resource|capitalize }}Facts(object):
     def __init__(self, module, subspec='config', options='options'):
         self._module = module
         self.argument_spec = {{ resource|capitalize }}Args.argument_spec
-        spec = deepcopy(self.argument_spec)
-        if subspec:
-            if options:
-                facts_argument_spec = spec[subspec][options]
-            else:
-                facts_argument_spec = spec[subspec]
-        else:
-            facts_argument_spec = spec
-
-        self.generated_spec = utils.generate_dict(facts_argument_spec)
 
     def populate_facts(self, connection, ansible_facts, data=None):
         """ Populate the facts for {{ resource|capitalize }} network resource
@@ -62,13 +52,13 @@ class {{ resource|capitalize }}Facts(object):
             data = connection.get()
 
         # parse native config using the {{ resource|capitalize }} template
-        {{ resource|lower }}_parser = {{ resource|capitalize }}Template(lines=data.splitlines())
+        {{ resource|lower }}_parser = {{ resource|capitalize }}Template(lines=data.splitlines(), module=self._module)
         objs = list({{ resource|lower }}_parser.parse().values())
 
         ansible_facts['ansible_network_resources'].pop('{{ resource }}', None)
 
         params = utils.remove_empties(
-            utils.validate_config(self.argument_spec, {"config": objs})
+            {{ resource|lower }}_parser.validate_config(self.argument_spec, {"config": objs}, redact=True)
         )
 
         facts['{{ resource }}'] = params['config']


### PR DESCRIPTION
Signed-off-by: NilashishC <nilashishchakraborty8@gmail.com>

This patch updates the facts template to use the base class validate_config() instead of utils validate_config(), so that the list of no_log values is correctly updated and all sensitive values are redacted from task result.

Reference PRs:
- https://github.com/ansible-collections/ansible.netcommon/pull/246/
- https://github.com/ansible-collections/cisco.nxos/pull/270
