### PR TITLE
Remove trailing spaces in rm_template

### DIFF
--- a/roles/scaffold_resource_module/templates/module_utils/network_os/rm_templates/resource.py.j2
+++ b/roles/scaffold_resource_module/templates/module_utils/network_os/rm_templates/resource.py.j2
@@ -8,9 +8,9 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 """
-The {{ resource|capitalize }} parser templates file. This contains 
-a list of parser definitions and associated functions that 
-facilitates both facts gathering and native command generation for 
+The {{ resource|capitalize }} parser templates file. This contains
+a list of parser definitions and associated functions that
+facilitates both facts gathering and native command generation for
 the given network resource.
 """
 


### PR DESCRIPTION
remove trailing spaces in rm templates.
This causing tox linters failures.